### PR TITLE
Ignore Null and Unknown in storage size validator

### DIFF
--- a/internal/validators/storage_size_validator.go
+++ b/internal/validators/storage_size_validator.go
@@ -21,6 +21,10 @@ func (v StorageSizeValidator) MarkdownDescription(ctx context.Context) string {
 
 //nolint:gocritic // Implements Terraform defined interface
 func (v StorageSizeValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
 	input := req.ConfigValue.ValueString()
 	input = strings.ToLower(input)
 


### PR DESCRIPTION
Using Crusoe resources in a child module triggers a validation error when passing the disk size as an input variable.

In this scenario, the validator is called both before the attribute is set and after. Most string validators in Hashicorp's terraform-plugin-framework-validators repo [1], for example, check for Null or Unknown and return.

This patch changes the storage size validator to do the same.

[1] https://github.com/hashicorp/terraform-plugin-framework-validators