### PR TITLE
Support Hot Attach/Detach

### DIFF
--- a/internal/disk/disk_resource.go
+++ b/internal/disk/disk_resource.go
@@ -276,7 +276,7 @@ func (r *diskResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	_, err = internal.AwaitOperation(ctx, dataResp.Operation, r.client.DiskOperationsApi.GetStorageDisksOperation)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete disk",
-			fmt.Sprintf("There was a deleting a disk: %s", err.Error()))
+			fmt.Sprintf("There was an error deleting a disk: %s", err.Error()))
 
 		return
 	}

--- a/internal/vm/vm_resource.go
+++ b/internal/vm/vm_resource.go
@@ -341,20 +341,6 @@ func (r *vmResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	instance, err := getVM(ctx, r.client, state.ID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find instance", "Could not find a matching VM instance.")
-
-		return
-	}
-
-	if instance.State != vmStateShutOff {
-		resp.Diagnostics.AddError("Instance is running",
-			"VMs must be stopped before attaching or detaching disks. Please stop the VM and try again.")
-
-		return
-	}
-
 	// attach/detach disks if requested
 	addedDisks, removedDisks := getDisksDiff(state.Disks, plan.Disks)
 	if len(addedDisks) > 0 {


### PR DESCRIPTION
Removes a client side check that no longer applies, now that Crusoe Cloud supports attaching/detaching disks from VMs that are still running.