### PR TITLE
Support vars in validators

### DIFF
--- a/internal/validators/regex_validator.go
+++ b/internal/validators/regex_validator.go
@@ -23,6 +23,11 @@ func (v RegexValidator) MarkdownDescription(ctx context.Context) string {
 
 //nolint:gocritic // Implements Terraform defined interface
 func (v RegexValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// skip validation if the value is still unknown, which is the case for vars before evaluation
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
 	r := regexp.MustCompile(v.RegexPattern)
 
 	if !r.MatchString(req.ConfigValue.ValueString()) {

--- a/internal/validators/ssh_key_validator.go
+++ b/internal/validators/ssh_key_validator.go
@@ -20,6 +20,11 @@ func (v SSHKeyValidator) MarkdownDescription(ctx context.Context) string {
 
 //nolint:gocritic // Implements Terraform defined interface
 func (v SSHKeyValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// skip validation if the value is still unknown, which is the case for vars before evaluation
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
 	input := req.ConfigValue.ValueString()
 
 	_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(input))


### PR DESCRIPTION
The SSH Key validator and Regex validator were susceptible to causing false negatives when the input was a tf variable. This adds an additional check that supports those cases by effectively deferring validation until the variable has been evaluated.