### PR TITLE
Allow Deleting Running VMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/antihax/optional v1.0.0
-	github.com/crusoecloud/client-go v0.1.21
+	github.com/crusoecloud/client-go v0.1.22
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,8 @@ github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwc
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crusoecloud/client-go v0.1.19 h1:VuNFnHGlYm4w15BnC7bVy2J38LHC+prlJ52BO4C5dEU=
-github.com/crusoecloud/client-go v0.1.19/go.mod h1:k1FgpUllEJtE53osEwsF+JfbFKILn5t3UuBdHYBVpdY=
-github.com/crusoecloud/client-go v0.1.21-0.20230817174003-13b353653e84 h1:kMyuAJqRIr58ltfoq7iWwcR37esbL66oaAOzpkh69S0=
-github.com/crusoecloud/client-go v0.1.21-0.20230817174003-13b353653e84/go.mod h1:k1FgpUllEJtE53osEwsF+JfbFKILn5t3UuBdHYBVpdY=
-github.com/crusoecloud/client-go v0.1.21 h1:RycEXM9WqMwIfBnQNAtgqplof0/eQqZ0DTIgVvXfAik=
-github.com/crusoecloud/client-go v0.1.21/go.mod h1:k1FgpUllEJtE53osEwsF+JfbFKILn5t3UuBdHYBVpdY=
+github.com/crusoecloud/client-go v0.1.22 h1:SE077syXicRyq9/1B9V1+ocYJdGZZRr6pdkimKhUPQM=
+github.com/crusoecloud/client-go v0.1.22/go.mod h1:k1FgpUllEJtE53osEwsF+JfbFKILn5t3UuBdHYBVpdY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/firewall_rule/firewall_rule_resource.go
+++ b/internal/firewall_rule/firewall_rule_resource.go
@@ -128,7 +128,7 @@ func (r *firewallRuleResource) Create(ctx context.Context, req resource.CreateRe
 	sourcePortsStr := strings.ReplaceAll(plan.SourcePorts.ValueString(), "*", "1-65535")
 	destPortsStr := strings.ReplaceAll(plan.DestinationPorts.ValueString(), "*", "1-65535")
 
-	dataResp, httpResp, err := r.client.VPCFirewallRulesApi.CreateVPCFirewallRule(ctx, swagger.VpcFirewallRulesPostRequest{
+	dataResp, httpResp, err := r.client.VPCFirewallRulesApi.CreateVPCFirewallRule(ctx, swagger.VpcFirewallRulesPostRequestV1Alpha4{
 		RoleId:           roleID,
 		VpcNetworkId:     plan.Network.ValueString(),
 		Name:             plan.Name.ValueString(),

--- a/internal/ib_partition/ib_partition_resource.go
+++ b/internal/ib_partition/ib_partition_resource.go
@@ -89,7 +89,7 @@ func (r *ibPartitionResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	dataResp, httpResp, err := r.client.IBPartitionsApi.CreateIBPartition(ctx, swagger.IbPartitionsPostRequest{
+	dataResp, httpResp, err := r.client.IBPartitionsApi.CreateIBPartition(ctx, swagger.IbPartitionsPostRequestV1Alpha4{
 		RoleId:      roleID,
 		Name:        plan.Name.ValueString(),
 		IbNetworkId: plan.IBNetworkID.ValueString(),

--- a/internal/util.go
+++ b/internal/util.go
@@ -86,7 +86,7 @@ func GetRole(ctx context.Context, api *swagger.APIClient) (string, error) {
 
 // AwaitOperation polls an async API operation until it resolves into a success or failure state.
 func AwaitOperation(ctx context.Context, op *swagger.Operation,
-	getFunc func(context.Context, string) (swagger.OperationsGetResponse, *http.Response, error)) (
+	getFunc func(context.Context, string) (swagger.ListOperationsResponseV1Alpha4, *http.Response, error)) (
 	*swagger.Operation, error,
 ) {
 	for op.State == string(OpInProgress) {
@@ -122,7 +122,7 @@ func AwaitOperation(ctx context.Context, op *swagger.Operation,
 // AwaitOperationAndResolve awaits an async API operation and attempts to parse the response as an instance of T,
 // if the operation was successful.
 func AwaitOperationAndResolve[T any](ctx context.Context, op *swagger.Operation,
-	getFunc func(context.Context, string) (swagger.OperationsGetResponse, *http.Response, error),
+	getFunc func(context.Context, string) (swagger.ListOperationsResponseV1Alpha4, *http.Response, error),
 ) (*T, *swagger.Operation, error) {
 	op, err := AwaitOperation(ctx, op, getFunc)
 	if err != nil {

--- a/internal/vm/vm_resource.go
+++ b/internal/vm/vm_resource.go
@@ -213,7 +213,7 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 		vmLocation = defaultVMLocation
 	}
 
-	dataResp, httpResp, err := r.client.VMsApi.CreateInstance(ctx, swagger.InstancesPostRequestV1Alpha3{
+	dataResp, httpResp, err := r.client.VMsApi.CreateInstance(ctx, swagger.InstancesPostRequestV1Alpha4{
 		RoleId:         roleID,
 		Name:           plan.Name.ValueString(),
 		ProductName:    plan.Type.ValueString(),
@@ -344,7 +344,7 @@ func (r *vmResource) Update(ctx context.Context, req resource.UpdateRequest, res
 	// attach/detach disks if requested
 	addedDisks, removedDisks := getDisksDiff(state.Disks, plan.Disks)
 	if len(addedDisks) > 0 {
-		attachResp, httpResp, err := r.client.VMsApi.UpdateInstanceAttachDisks(ctx, swagger.InstancesAttachDiskPostRequest{
+		attachResp, httpResp, err := r.client.VMsApi.UpdateInstanceAttachDisks(ctx, swagger.InstancesAttachDiskPostRequestV1Alpha4{
 			AttachDisks: addedDisks,
 		}, state.ID.ValueString())
 		if err != nil {
@@ -395,15 +395,9 @@ func (r *vmResource) Delete(ctx context.Context, req resource.DeleteRequest, res
 		return
 	}
 
-	instance, err := getVM(ctx, r.client, state.ID.ValueString())
+	_, err := getVM(ctx, r.client, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to find instance", "Could not find a matching VM instance.")
-
-		return
-	}
-	if instance.State != vmStateShutOff {
-		resp.Diagnostics.AddError("Instance is running",
-			"Instances must be shut off before they can be deleted. This will be changed in a future release.")
 
 		return
 	}


### PR DESCRIPTION
Removes the client side check that an instance is stopped before attempting to delete it, now that the Crusoe Cloud API supports deleting running instances.