### PR TITLE
Patch Unexpected HCAs

### DIFF
--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// TODO: pull from config set during build
-	version = "v0.5.0"
+	version = "v0.5.1"
 
 	pollInterval = 2 * time.Second
 
@@ -150,7 +150,7 @@ func GetFallbackProject(ctx context.Context, client *swagger.APIClient, diag *di
 		diag.AddWarning("Default project not specified",
 			fmt.Sprintf("A project_id was not specified in the configuration file. "+
 				"Please specify a project in the terraform file or set a 'default_project' in your configuration file. "+
-			"Falling back to project: %s.", dataResp.Items[0].Name))
+				"Falling back to project: %s.", dataResp.Items[0].Name))
 	}
 
 	return projectID, nil

--- a/internal/vm/util.go
+++ b/internal/vm/util.go
@@ -63,9 +63,9 @@ func getDisksDiff(origDisks, newDisks []vmDiskResourceModel) (disksAdded []swagg
 		}
 		if !matched {
 			disksAdded = append(disksAdded, swagger.DiskAttachment{
-				DiskId: newDisk.ID,
+				DiskId:         newDisk.ID,
 				AttachmentType: newDisk.AttachmentType,
-				Mode: newDisk.Mode,
+				Mode:           newDisk.Mode,
 			})
 		}
 	}
@@ -168,7 +168,6 @@ func vmNetworkInterfacesToTerraformResourceModel(networkInterfaces []swagger.Net
 func vmPartialHostChannelAdaptersToTerraformResourceModel(hostChannelAdapters []swagger.HostChannelAdapter) (hostChannelAdaptersList types.List, warning string) {
 	hcas := make([]vmHostChannelAdapterResourceModel, 0, len(hostChannelAdapters))
 	for _, hca := range hostChannelAdapters {
-
 		hcas = append(hcas, vmHostChannelAdapterResourceModel{
 			IBPartitionID: hca.IbPartitionId,
 		})

--- a/internal/vm/vm_resource.go
+++ b/internal/vm/vm_resource.go
@@ -332,6 +332,7 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	plan.ID = types.StringValue(instance.Id)
+	plan.ProjectID = types.StringValue(projectID)
 
 	networkInterfaces, _ := vmNetworkInterfacesToTerraformResourceModel(instance.NetworkInterfaces)
 	plan.NetworkInterfaces = networkInterfaces
@@ -343,10 +344,6 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 		}
 		plan.Disks = disks
 	}
-
-	plan.ProjectID = types.StringValue(projectID)
-	hcas, _ := vmPartialHostChannelAdaptersToTerraformResourceModel(instance.HostChannelAdapters)
-	plan.HostChannelAdapters = hcas
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Fixes an issue in which the provider throws errors on successful creation of an Infiniband enabled VM, due to the provider not expecting to receive all 8 HCA definitions.