### PR TITLE
Update HCAs for non IB VMs

### DIFF
--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// TODO: pull from config set during build
-	version = "v0.5.1"
+	version = "v0.5.2"
 
 	pollInterval = 2 * time.Second
 

--- a/internal/vm/vm_resource.go
+++ b/internal/vm/vm_resource.go
@@ -208,8 +208,8 @@ func (r *vmResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 				},
 			},
 			"host_channel_adapters": schema.ListNestedAttribute{
-				Computed:      true,
 				Optional:      true,
+				Computed:      true,
 				PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()}, // maintain across updates
 				NestedObject: schema.NestedAttributeObject{
 					PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()}, // maintain across updates
@@ -300,6 +300,9 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 				},
 			}
 		}
+	} else {
+		// explicitly set a null value for non IB enabled VMs
+		plan.HostChannelAdapters = types.ListNull(vmHostChannelAdapterSchema)
 	}
 
 	dataResp, httpResp, err := r.client.VMsApi.CreateInstance(ctx, swagger.InstancesPostRequestV1Alpha5{


### PR DESCRIPTION
Updates the provider to explicitly set the Host Channel Adapters for non IB VMs to a null list, to prevent Terraform from entering an unknown state around HCAs.