### PR TITLE
feat: configure default project via env var

### DIFF
--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -60,6 +60,7 @@ func GetConfig() (*Config, error) {
 	accessKey := os.Getenv("CRUSOE_ACCESS_KEY_ID")
 	secretKey := os.Getenv("CRUSOE_SECRET_KEY")
 	apiEndpoint := os.Getenv("CRUSOE_API_ENDPOINT")
+	defaultProject := os.Getenv("CRUSOE_DEFAULT_PROJECT")
 
 	if accessKey != "" {
 		config.AccessKeyID = accessKey
@@ -69,6 +70,9 @@ func GetConfig() (*Config, error) {
 	}
 	if apiEndpoint != "" {
 		config.ApiEndpoint = apiEndpoint
+	}
+	if defaultProject != "" {
+		config.DefaultProject = defaultProject
 	}
 
 	return &config, nil


### PR DESCRIPTION
This commit introduces support for automatically discovering a default
project using the `CRUSOE_DEFAULT_PROJECT` environment variable.

Frustrutingly, some aspects of the provider can be configured using the
same environment variables as the Crusoe CLI, namely
`CRUSOE_ACCESS_KEY_ID` and `CRUSOE_SECRET_KEY` , but the provider
ignores the `CRUSOE_DEFAULT_PROJECT` variable the the CLI supports.

Signed-off-by: squat <lserven@gmail.com>
