### PR TITLE
feat: capacity in data.ib_network

### DIFF
--- a/internal/ib_network/ib_network_data_source.go
+++ b/internal/ib_network/ib_network_data_source.go
@@ -21,7 +21,7 @@ type ibNetworksDataSourceModel struct {
 }
 
 type ibNetworkCapacityModel struct {
-	Quantity  int32  `tfsdk:"quantity"`
+	Quantity  int64  `tfsdk:"quantity"`
 	SliceType string `tfsdk:"slice_type"`
 }
 
@@ -71,6 +71,19 @@ func (ds *ibNetworksDataSource) Schema(ctx context.Context, request datasource.S
 					"location": schema.StringAttribute{
 						Computed: true,
 					},
+					"capacities": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"quantity": schema.Int64Attribute{
+									Computed: true,
+								},
+								"slice_type": schema.StringAttribute{
+									Computed: true,
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -100,7 +113,7 @@ func (ds *ibNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 		capacities := make([]ibNetworkCapacityModel, 0, len(dataResp.Items[i].Capacities))
 		for _, c := range dataResp.Items[i].Capacities {
 			capacities = append(capacities, ibNetworkCapacityModel{
-				Quantity:  c.Quantity,
+				Quantity:  int64(c.Quantity),
 				SliceType: c.SliceType,
 			})
 		}

--- a/internal/ib_network/ib_network_data_source.go
+++ b/internal/ib_network/ib_network_data_source.go
@@ -20,10 +20,16 @@ type ibNetworksDataSourceModel struct {
 	IBNetworks []ibNetworkModel `tfsdk:"ib_networks"`
 }
 
+type ibNetworkCapacityModel struct {
+	Quantity  int32  `tfsdk:"quantity"`
+	SliceType string `tfsdk:"slice_type"`
+}
+
 type ibNetworkModel struct {
-	ID       string `tfsdk:"id"`
-	Name     string `tfsdk:"name"`
-	Location string `tfsdk:"location"`
+	ID         string                   `tfsdk:"id"`
+	Name       string                   `tfsdk:"name"`
+	Location   string                   `tfsdk:"location"`
+	Capacities []ibNetworkCapacityModel `tfsdk:"capacities"`
 }
 
 func NewIBNetworkDataSource() datasource.DataSource {
@@ -91,10 +97,18 @@ func (ds *ibNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	var state ibNetworksDataSourceModel
 	for i := range dataResp.Items {
+		capacities := make([]ibNetworkCapacityModel, 0, len(dataResp.Items[i].Capacities))
+		for _, c := range dataResp.Items[i].Capacities {
+			capacities = append(capacities, ibNetworkCapacityModel{
+				Quantity:  c.Quantity,
+				SliceType: c.SliceType,
+			})
+		}
 		state.IBNetworks = append(state.IBNetworks, ibNetworkModel{
-			ID:       dataResp.Items[i].Id,
-			Name:     dataResp.Items[i].Name,
-			Location: dataResp.Items[i].Location,
+			ID:         dataResp.Items[i].Id,
+			Name:       dataResp.Items[i].Name,
+			Location:   dataResp.Items[i].Location,
+			Capacities: capacities,
 		})
 	}
 


### PR DESCRIPTION
This commit adds the `capacities` field from the Crusoe API response
model for `ib_network`s to the `ib_network` data source. This is
important for Terraform modules to be able to filter available networks
from the data source response based on the `slice_type` and the
avalability in the `quantity` field.

Note: this data is already readily available in the public Crusoe JSON
API; this commit merely translates it into the provider for Terraform
users to benefit from it.

Signed-off-by: squat <lserven@gmail.com>
