### PR TITLE
Support for comma-separated CIDRs in `destination`/`source` of firewall rules

### DIFF
--- a/internal/firewall_rule/firewall_rule_resource.go
+++ b/internal/firewall_rule/firewall_rule_resource.go
@@ -157,9 +157,9 @@ func (r *firewallRuleResource) Create(ctx context.Context, req resource.CreateRe
 		Action:           plan.Action.ValueString(),
 		Protocols:        stringToSlice(plan.Protocols.ValueString(), ","),
 		Direction:        plan.Direction.ValueString(),
-		Sources:          []swagger.FirewallRuleObject{toFirewallRuleObject(plan.Source.ValueString())},
+		Sources:          toFirewallRuleObjects(stringToSlice(plan.Source.ValueString(), ",")),
 		SourcePorts:      stringToSlice(sourcePortsStr, ","),
-		Destinations:     []swagger.FirewallRuleObject{toFirewallRuleObject(plan.Destination.ValueString())},
+		Destinations:     toFirewallRuleObjects(stringToSlice(plan.Destination.ValueString(), ",")),
 		DestinationPorts: stringToSlice(destPortsStr, ","),
 	}, projectID)
 	if httpResp != nil {
@@ -235,13 +235,13 @@ func (r *firewallRuleResource) Update(ctx context.Context, req resource.UpdateRe
 		patchReq.Protocols = stringToSlice(plan.Protocols.ValueString(), ",")
 	}
 	if !plan.Destination.IsNull() && !plan.Destination.IsUnknown() {
-		patchReq.Destinations = []swagger.FirewallRuleObject{toFirewallRuleObject(plan.Destination.ValueString())}
+		patchReq.Destinations = toFirewallRuleObjects(stringToSlice(plan.Destination.ValueString(), ","))
 	}
 	if !plan.DestinationPorts.IsNull() && !plan.DestinationPorts.IsUnknown() {
 		patchReq.DestinationPorts = stringToSlice(plan.DestinationPorts.ValueString(), ",")
 	}
 	if !plan.Source.IsNull() && !plan.Source.IsUnknown() {
-		patchReq.Sources = []swagger.FirewallRuleObject{toFirewallRuleObject(plan.Source.ValueString())}
+		patchReq.Sources = toFirewallRuleObjects(stringToSlice(plan.Source.ValueString(), ","))
 	}
 	if !plan.SourcePorts.IsNull() && !plan.SourcePorts.IsUnknown() {
 		patchReq.SourcePorts = stringToSlice(plan.SourcePorts.ValueString(), ",")

--- a/internal/firewall_rule/util.go
+++ b/internal/firewall_rule/util.go
@@ -102,9 +102,14 @@ func preserveListFormat(configured string, apiElems []string, expandWildcard boo
 	return strings.Join(apiElems, ",")
 }
 
-// toFirewallRuleObject wraps an IP or CIDR string into a FirewallRuleObject.
-func toFirewallRuleObject(ipOrCIDR string) swagger.FirewallRuleObject {
-	return swagger.FirewallRuleObject{Cidr: ipOrCIDR}
+// toFirewallRuleObjects wraps IP or CIDR strings into an array of FirewallRuleObject.
+func toFirewallRuleObjects(ipsOrCIDRs []string) []swagger.FirewallRuleObject {
+	firewallRuleObjects := make([]swagger.FirewallRuleObject, 0, len(ipsOrCIDRs))
+	for _, ipOrCIDR := range ipsOrCIDRs {
+		firewallRuleObjects = append(firewallRuleObjects, swagger.FirewallRuleObject{Cidr: ipOrCIDR})
+	}
+
+	return firewallRuleObjects
 }
 
 // stringToSlice splits a delimited string list into a slice of strings.

--- a/internal/firewall_rule/util_test.go
+++ b/internal/firewall_rule/util_test.go
@@ -112,6 +112,52 @@ func Test_preserveListFormat(t *testing.T) {
 	}
 }
 
+func Test_toFirewallRuleObjects(t *testing.T) {
+	type args struct {
+		ipsOrCIDRs []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []swagger.FirewallRuleObject
+	}{
+		{
+			name: "empty list",
+			args: args{},
+			want: []swagger.FirewallRuleObject{},
+		},
+		{
+			name: "single CIDR",
+			args: args{ipsOrCIDRs: []string{"127.0.0.0/16"}},
+			want: []swagger.FirewallRuleObject{{Cidr: "127.0.0.0/16"}},
+		},
+		{
+			name: "multiple CIDRs",
+			args: args{ipsOrCIDRs: []string{"127.0.0.0/16", "127.0.0.1/24"}},
+			want: []swagger.FirewallRuleObject{{Cidr: "127.0.0.0/16"}, {Cidr: "127.0.0.1/24"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toFirewallRuleObjects(tt.args.ipsOrCIDRs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toFirewallRuleObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_toFirewallRuleObjects_splitsCommaSeparatedList guards the create/update
+// path: a comma-separated source or destination must reach the API as one object
+// per CIDR, not a single object holding the whole string.
+func Test_toFirewallRuleObjects_splitsCommaSeparatedList(t *testing.T) {
+	got := toFirewallRuleObjects(stringToSlice("1.1.1.1/32, 2.2.2.2/32", ","))
+	want := []swagger.FirewallRuleObject{{Cidr: "1.1.1.1/32"}, {Cidr: "2.2.2.2/32"}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("toFirewallRuleObjects(stringToSlice()) = %v, want %v", got, want)
+	}
+}
+
 // Test_firewallRuleToTerraformResourceModel_preservesConfiguredFormat is the
 // regression guard for CCX-4493: a user-configured "*" must survive the
 // transform even though the API expands it to "1-65535".


### PR DESCRIPTION
## Problem

Given the following firewall resource definition:

```hcl
resource "crusoe_vpc_firewall_rule" "test" {
  network           = "..."
  name              = "test"
  action            = "allow"
  direction         = "ingress"
  protocols         = "tcp"
  source            = "1.1.1.1/32,2.2.2.2/32"
  source_ports      = "1-65535"
  destination       = "..."
  destination_ports = "22"
}
```

The following `terraform plan` is produced:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # crusoe_vpc_firewall_rule.test will be created
  + resource "crusoe_vpc_firewall_rule" "test" {
      + action            = "allow"
      + destination       = "..."
      + destination_ports = "22"
      + direction         = "ingress"
      + id                = (known after apply)
      + name              = "test"
      + network           = "..."
      + project_id        = (known after apply)
      + protocols         = "tcp"
      + source            = "1.1.1.1/32,2.2.2.2/32"
      + source_ports      = "1-65535"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

But attempting to `terraform apply`:

```
crusoe_vpc_firewall_rule.test: Creating...
╷
│ Error: Failed to create firewall rule
│ 
│   with crusoe_vpc_firewall_rule.test,
│   on vpc.tf line 1, in resource "crusoe_vpc_firewall_rule" "test":
│  1: resource "crusoe_vpc_firewall_rule" "test" {
│ 
│ There was an error starting a create firewall rule operation: bad request, check request parameters: failed to validate CIDR address: failed to parse cidr: invalid CIDR address: 1.1.1.1/32,2.2.2.2/32
╵
```

## Cause

Provider always creates a single-item array of `FirewallRuleObject` with the input string passed to it verbatim:

https://github.com/crusoecloud/terraform-provider-crusoe/blob/a5a3bf996a60c7643909613983505d6adf7bfdbe/internal/firewall_rule/firewall_rule_resource.go#L160-L162

## Solution

Split input on comma and update utility to construct `FirewallRuleObject` arrays from these inputs.

## Notes

Added some tests for the functionality.